### PR TITLE
Boxes

### DIFF
--- a/MewsUtils/Posts.py
+++ b/MewsUtils/Posts.py
@@ -13,7 +13,7 @@ from . import Connection
 
 ### Functions
 
-def getTrendingPosts(upper, lower, skip, amount):
+def getTrendingPosts(upper, lower, skip, amount, getBoxes):
     # Check Arguments
     try:
         assert(skip >= 0)
@@ -82,6 +82,26 @@ def getTrendingPosts(upper, lower, skip, amount):
             'when_updated': when_updated
         }
         trendingPosts.append(post)
+
+    # Get Boxes for Each Post
+    if getBoxes is True:
+        for post in trendingPosts:
+
+            sql = '''
+            SELECT DISTINCT sub_img_meta
+            FROM mews_app.PostRelatedness
+            WHERE post1_id = %(pid)s
+            ;
+            '''
+            args = { 'pid': post['id'] }
+            cursor.execute(sql, args)
+
+            boxes = []
+            for result in cursor.fetchall():
+                (box,) = result
+                boxes.append(box)
+
+            post['boxes'] = boxes
 
     cnx.close()
 

--- a/MewsUtils/Posts.py
+++ b/MewsUtils/Posts.py
@@ -143,6 +143,24 @@ def getPost(pid):
             'when_updated': when_updated
             }
 
+    sql = '''
+    SELECT DISTINCT sub_img_meta
+    FROM mews_app.PostRelatedness
+    WHERE post1_id = %(pid)s
+    ;
+    '''
+    args = { 'pid': pid }
+
+    # Query DB
+    cursor.execute(sql, args)
+
+    boxes = []
+    for result in cursor.fetchall():
+        (box,) = result
+        boxes.append(box)
+
+    post['boxes'] = boxes
+        
     cnx.close()
 
     return post, 200

--- a/app.py
+++ b/app.py
@@ -27,10 +27,11 @@ def getTrending():
     @route   GET /posts/trending
     @desc    Returns the trending posts within timeline
     --
-    @param   skip   - number of posts to skip (int)
-    @param   amount - number of posts to return (int)
-    @param   lower  - lower bound for when_posted (datetime syntax)
-    @param   upper  - upper bound for when_posted (datetime syntax)
+    @param   skip      - number of posts to skip (int)
+    @param   amount    - number of posts to return (int)
+    @param   lower     - lower bound for when_posted (datetime syntax)
+    @param   upper     - upper bound for when_posted (datetime syntax)
+    @param   getBoxes  - bool to get bounding boxes or not (takes longer to get boxes, so false by default)
     --
     @return  list of trending posts
     """

--- a/app.py
+++ b/app.py
@@ -40,9 +40,10 @@ def getTrending():
     lower = request.args.get('lower', type=str, default = str(datetime.now() - timedelta(days=30)))
     skip = request.args.get('skip', type=int, default=0)
     amount = request.args.get('amount', type=int, default=10)
+    getBoxes = request.args.get('getBoxes', type=bool, default=False)
 
     # Call Internal Function
-    trendPosts, code = Posts.getTrendingPosts(upper, lower, skip, amount)
+    trendPosts, code = Posts.getTrendingPosts(upper, lower, skip, amount, getBoxes)
 
     return jsonify(trendPosts), code
 


### PR DESCRIPTION
Updates two endpoints:

- `/posts/<pid>`: by default, grabs unique boxes from PostRelatedness for post1_id.
- `/posts/trending`: does NOT grab by default. Have to pass `getBoxes` param. Reason is to allow for front-end to test whether speed difference is worth it or not.